### PR TITLE
Handle multiline copy/paste better during configuration.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32doit-devkit-v1]
-platform = espressif32
+platform = platformio/espressif32@^4.4.0
 board = esp32doit-devkit-v1
 framework = arduino
 board_build.mcu = esp32

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -352,7 +352,7 @@ void loop()
 	vTaskDelay(1000 / portTICK_PERIOD_MS);
 	if (Serial.available())
 	{
-		String command = Serial.readString();
+		String command = Serial.readStringUntil('\n');
 		if (command.startsWith(F("WifiSSID->")))
 		{
 			sprintf(config.wifi_ssid, command.substring(10).c_str());


### PR DESCRIPTION
When testing the latest in main, it seemed to read multiple lines of input (saved during configuration) into EEPROM, causing the board to complain about the saved SSID being too long. This is a slight tweak to stop reading from the serial port as soon as a newline's seen.